### PR TITLE
Update to Zig-0.10.0

### DIFF
--- a/src/arrayIterator.zig
+++ b/src/arrayIterator.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const TypeId = @import("builtin").TypeId;
 
 pub fn iterator(comptime BaseType: type) type {
     return struct {
@@ -16,7 +15,7 @@ pub fn iterator(comptime BaseType: type) type {
         }
 
         pub fn count(self: *Self) usize {
-            return raw.len;
+            return self.raw.len;
         }
 
         pub fn reset(self: *Self) void {

--- a/src/info.zig
+++ b/src/info.zig
@@ -2,49 +2,24 @@ const std = @import("std");
 const arrayIt = @import("arrayIterator.zig").iterator;
 const iterator = @import("iterator.zig").iterator;
 const enumerateIt = @import("enumerate.zig").iterator;
-const TypeId = @import("builtin").TypeId;
-const mem = std.mem;
-
-const Info = enum {
-    Slice,
-    Iterator,
-    Other,
-};
-
-pub fn hasIteratorMember(comptime objType: type) bool {
-    comptime {
-        if (@typeId(objType) != TypeId.Struct) {
-            return false;
-        }
-
-        const count = @memberCount(objType);
-        var i = 0;
-
-        inline while (i < count) : (i += 1) {
-            if (mem.eql(u8, @memberName(objType, i), "iterator")) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-}
 
 pub fn getType(comptime objType: type) type {
     comptime {
         switch (@typeInfo(objType)) {
-            TypeId.Pointer => |pointer| {
-                switch (pointer.size) {
-                    .One, .Many, .C => {
-                        return pointer.child;
-                    },
-                    .Slice => {
-                        const BaseType = pointer.child;
-                        return iterator(BaseType, arrayIt(BaseType));
-                    },
-                }
+            .Pointer => |pointer| {
+                const BaseType = blk: {
+                    switch (pointer.size) {
+                        .One, .Many, .C => {
+                            break :blk @typeInfo(pointer.child).Array.child;
+                        },
+                        .Slice => {
+                            break :blk pointer.child;
+                        },
+                    }
+                };
+                return iterator(BaseType, arrayIt(BaseType));
             },
-            TypeId.Struct => |structInfo| {
+            .Struct => {
                 if (!hasIteratorMember(objType)) {
                     @compileError("No 'iterator' or 'Child' property found");
                 }
@@ -60,30 +35,51 @@ pub fn getType(comptime objType: type) type {
     }
 }
 
-pub fn findTillNoChild(comptime Type: type) type {
-    if (@typeId(Type) == TypeId.Nullable) {
-        return findTillNoChild(Type.Child);
-    }
-    return Type;
-}
-
-pub fn initType(comptime objType: type, value: var) getType(objType) {
-    comptime const it_type = getType(objType);
+pub fn initType(comptime objType: type, value: anytype) getType(objType) {
+    const it_type = getType(objType);
     switch (@typeInfo(objType)) {
-        TypeId.Pointer => |pointer| {
-            switch (pointer.size) {
-                .Slice => {
-                    return it_type{ .nextIt = arrayIt(pointer.child).init(value) };
-                },
-                else => unreachable,
-            }
+        .Pointer => |pointer| {
+            const child = blk: {
+                switch (pointer.size) {
+                    .One, .Many, .C => {
+                        break :blk @typeInfo(pointer.child).Array.child;
+                    },
+                    .Slice => {
+                        break :blk pointer.child;
+                    },
+                }
+            };
+            return it_type{ .nextIt = arrayIt(child).init(value) };
         },
-        TypeId.Struct => {
+        .Struct => {
             if (comptime !hasIteratorMember(objType)) {
                 unreachable;
             }
             return it_type{ .nextIt = value.iterator() };
         },
         else => unreachable,
+    }
+}
+
+fn findTillNoChild(comptime Type: type) type {
+    if (@typeInfo(Type) == .Optional) {
+        return findTillNoChild(Type.Child);
+    }
+    return Type;
+}
+
+fn hasIteratorMember(comptime objType: type) bool {
+    comptime {
+        if (@typeInfo(objType) != .Struct) {
+            return false;
+        }
+
+        inline for (@typeInfo(objType).Struct.fields) |f| {
+            if (std.mem.eql(u8, @field(objType, f.name), "iterator")) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/iterator.zig
+++ b/src/iterator.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const TypeId = @import("builtin").TypeId;
 const whereIt = @import("where.zig").iterator;
 const selectIt = @import("select.zig").iterator;
 const castIt = @import("cast.zig").iterator;
@@ -102,33 +101,33 @@ pub fn iterator(comptime BaseType: type, comptime ItType: type) type {
             };
         }
 
-        fn performTransform(self: *Self, comptime func: fn (BaseType, BaseType) BaseType, comptime average: bool) ?BaseType {
-            var aggregate: ?BaseType = null;
+        fn performTransform(self: *Self, comptime func: fn (BaseType, BaseType) BaseType, comptime avg: bool) ?BaseType {
+            var agg: ?BaseType = null;
             self.reset();
             defer self.reset();
             var cnt: usize = 0;
 
             while (self.next()) |nxt| {
                 cnt += 1;
-                if (aggregate == null) {
-                    aggregate = nxt;
+                if (agg == null) {
+                    agg = nxt;
                 } else {
-                    aggregate = func(aggregate, nxt);
+                    agg = func(agg, nxt);
                 }
             }
 
-            if (aggregate and average) |agg| {
-                return agg / cnt;
+            if (agg and avg) |some_agg| {
+                return some_agg / cnt;
             } else {
-                return aggregate;
+                return agg;
             }
         }
 
-        pub fn average(self: *Self, comptime func: fn (BaseType, BaseType) BaseType) ?BaseType {
+        pub fn average(_: *Self, comptime func: fn (BaseType, BaseType) BaseType) ?BaseType {
             return performTransform(func, true);
         }
 
-        pub fn aggregate(self: *Self, comptime func: fn (BaseType, BaseType) BaseType) ?BaseType {
+        pub fn aggregate(_: *Self, comptime func: fn (BaseType, BaseType) BaseType) ?BaseType {
             return performTransform(func, false);
         }
 

--- a/src/order.zig
+++ b/src/order.zig
@@ -20,7 +20,7 @@ pub fn iterator(comptime BaseType: type, comptime NewType: type, comptime ItType
                 }
 
                 self.count = i;
-                sort(BaseType, self.buf[0..self.count], compare);
+                sort(BaseType, self.buf[0..self.count], {}, compare);
             }
 
             if (self.index >= self.count) return null;
@@ -33,7 +33,7 @@ pub fn iterator(comptime BaseType: type, comptime NewType: type, comptime ItType
             self.nextIt.reset();
         }
 
-        fn compare(a: BaseType, b: BaseType) bool {
+        fn compare(_: void, a: BaseType, b: BaseType) bool {
             if (ascending) {
                 return select(a) < select(b);
             } else {

--- a/src/select.zig
+++ b/src/select.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn iterator(comptime BaseType: type, comptime NewType: type, comptime ItType: type, select: fn (BaseType) NewType) type {
+pub fn iterator(comptime BaseType: type, comptime NewType: type, comptime ItType: type, comptime select: fn (BaseType) NewType) type {
     return struct {
         nextIt: *ItType,
 

--- a/src/selectMany.zig
+++ b/src/selectMany.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const info = @import("info.zig");
 const arrayIt = @import("arrayIterator.zig").iterator;
 
-pub fn iterator(comptime BaseType: type, comptime NewType: type, comptime ItType: type, select: fn (BaseType) []const NewType) type {
+pub fn iterator(comptime BaseType: type, comptime NewType: type, comptime ItType: type, comptime select: fn (BaseType) []const NewType) type {
     return struct {
         nextIt: *ItType,
         currentIt: ?arrayIt(NewType),
@@ -30,7 +30,7 @@ pub fn iterator(comptime BaseType: type, comptime NewType: type, comptime ItType
             self.currentIt = null;
         }
 
-        pub fn count(self: *Self) usize {
+        pub fn count(_: *Self) usize {
             @compileError("Can't use count on select many");
         }
     };

--- a/src/skip.zig
+++ b/src/skip.zig
@@ -1,16 +1,17 @@
 const std = @import("std");
 
-pub fn iterator(comptime BaseType: type, comptime amount: usize) type {
+pub fn iterator(comptime BaseType: type, comptime ItType: type, comptime amount: usize) type {
     return struct {
         nextIt: *ItType,
 
-        const Self = this;
+        const Self = @This();
+        var i: usize = 0;
         var skipped: bool = false;
 
         pub fn next(self: *Self) ?BaseType {
             if (!skipped) {
                 skipped = true;
-                var i: usize = 0;
+                i = 0;
                 while (i < amount) : (i += 1) {
                     if (self.nextIt.next() == null) return null;
                 }
@@ -24,7 +25,7 @@ pub fn iterator(comptime BaseType: type, comptime amount: usize) type {
             i = 0;
         }
 
-        pub fn count(self: *Self) i32 {
+        pub fn count(_: *Self) i32 {
             return amount;
         }
     };

--- a/src/skipWhile.zig
+++ b/src/skipWhile.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 
-pub fn iterator(comptime BaseType: type, comptime condition: fn (BaseType) bool) type {
+pub fn iterator(comptime BaseType: type, comptime ItType: type, comptime condition: fn (BaseType) bool) type {
     return struct {
         nextIt: *ItType,
 
-        const Self = this;
+        const Self = @This();
         var skipped: bool = false;
 
         pub fn next(self: *Self) ?BaseType {
@@ -21,11 +21,10 @@ pub fn iterator(comptime BaseType: type, comptime condition: fn (BaseType) bool)
 
         pub fn reset(self: *Self) void {
             self.nextIt.reset();
-            i = 0;
         }
 
-        pub fn count(self: *Self) i32 {
-            return amount;
+        pub fn count(_: *Self) usize {
+            @compileError("Count not suitable on skip while");
         }
     };
 }

--- a/src/take.zig
+++ b/src/take.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 
-pub fn iterator(comptime BaseType: type, comptime amount: usize) type {
+pub fn iterator(comptime BaseType: type, comptime ItType: type, comptime amount: usize) type {
     return struct {
         nextIt: *ItType,
 
-        const Self = this;
+        const Self = @This();
         var i: usize = 0;
 
         pub fn next(self: *Self) ?BaseType {
@@ -22,7 +22,7 @@ pub fn iterator(comptime BaseType: type, comptime amount: usize) type {
             i = 0;
         }
 
-        pub fn count(self: *Self) i32 {
+        pub fn count(_: *Self) i32 {
             return amount;
         }
     };

--- a/src/takeWhile.zig
+++ b/src/takeWhile.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 
-pub fn iterator(comptime BaseType: type, comptime condition: fn (BaseType) bool) type {
+pub fn iterator(comptime BaseType: type, comptime ItType: type, comptime condition: fn (BaseType) bool) type {
     return struct {
         nextIt: *ItType,
 
-        const Self = this;
+        const Self = @This();
         var reachedCondition: bool = false;
 
         pub fn next(self: *Self) ?BaseType {
@@ -25,7 +25,7 @@ pub fn iterator(comptime BaseType: type, comptime condition: fn (BaseType) bool)
             reachedCondition = false;
         }
 
-        pub fn count(self: *Self) usize {
+        pub fn count(_: *Self) usize {
             @compileError("Count not suitable on take while");
         }
     };

--- a/src/where.zig
+++ b/src/where.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn iterator(comptime BaseType: type, comptime ItType: type, filter: fn (BaseType) bool) type {
+pub fn iterator(comptime BaseType: type, comptime ItType: type, comptime filter: fn (BaseType) bool) type {
     return struct {
         nextIt: *ItType,
 


### PR DESCRIPTION
Thanks for making this library.

All tests are passing on zig-0.10.0.

Function signatures would need further alteration to support chaining iterators on a single line, per the readme:

```zig
var rangeIt = lazy.range(0, 100, 1).where(even).select(pow);
```