### PR TITLE
0.11.0 Fixes

### DIFF
--- a/src/iterator.zig
+++ b/src/iterator.zig
@@ -219,12 +219,12 @@ pub fn iterator(comptime BaseType: type, comptime ItType: type) type {
             return buffer[0..c];
         }
 
-        pub fn toList(self: *Self, allocator: *std.mem.Allocator) std.ArrayList(BaseType) {
+        pub fn toList(self: *Self, allocator: std.mem.Allocator) !std.ArrayList(BaseType) {
             self.reset();
             defer self.reset();
             var list = std.ArrayList(BaseType).init(allocator);
             while (self.next()) |nxt| {
-                list.append(nxt);
+                try list.append(nxt);
             }
             return list;
         }


### PR DESCRIPTION
I'm submitting this as a draft PR as it's not fully working yet and could use some more eyes.

1. toList requires try for the allocations
2. struct/iterator code not compiling

However, I am unable to get the struct/iterator working for a hashmap at the moment as it just says on the `lazy.init` that it is unable to resolve comptime value.

```zig
		var test_map = std.StringHashMap(u8).init(allocator);
		var lazy_t_itr = lazy.init(test_map);
```

I find this weird because as far as I can see this type should be available at comptime. 

If you have any further thoughts as to how to get this working I'd appreciate it.